### PR TITLE
IMPROVE: Move sources dir to /usr/local/src

### DIFF
--- a/dummy-services-master/services/go/Dockerfile
+++ b/dummy-services-master/services/go/Dockerfile
@@ -2,8 +2,8 @@ FROM golang:1.15-alpine3.13 as builder
 
 RUN apk add --no-cache git
 
-COPY ./go-service /usr/src/go-service
-WORKDIR /usr/src/go-service
+COPY ./go-service /usr/local/src/go-service
+WORKDIR /usr/local/src/go-service
 COPY go.mod .
 COPY go.sum .
 

--- a/dummy-services-master/services/python/Dockerfile
+++ b/dummy-services-master/services/python/Dockerfile
@@ -7,14 +7,14 @@ RUN apt-get update && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
 
-COPY ./protobuf /usr/src/protobuf
-COPY python-service /usr/src/python-service/
+COPY ./protobuf /usr/local/src/protobuf
+COPY python-service /usr/local/src/python-service/
 
-RUN mkdir /usr/src/python-protobuf-generated && \
-  protoc --proto_path=/usr/src \
-    --python_out=/usr/src/python-protobuf-generated \
-    /usr/src/protobuf/helloworld.proto && \
-   cp /usr/src/python-protobuf-generated/protobuf/* /usr/src/python-service/
+RUN mkdir /usr/local/src/python-protobuf-generated && \
+  protoc --proto_path=/usr/local/src \
+    --python_out=/usr/local/src/python-protobuf-generated \
+    /usr/local/src/protobuf/helloworld.proto && \
+   cp /usr/local/src/python-protobuf-generated/protobuf/* /usr/local/src/python-service/
 
 
 FROM python:3.8-slim-buster as virtualenv
@@ -28,8 +28,8 @@ ENV VIRTUAL_ENV=/opt/virtualenv
 RUN python3 -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-COPY ./requirements.txt /usr/src/python-requirements/
-RUN pip install -r /usr/src/python-requirements/requirements.txt
+COPY ./requirements.txt /usr/local/src/python-requirements/
+RUN pip install -r /usr/local/src/python-requirements/requirements.txt
 
 
 FROM python:3.8-slim-buster as app
@@ -42,11 +42,11 @@ ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
 ENV PIP_DISABLE_PIP_VERSION_CHECK=1
 
-COPY --from=builder /usr/src/python-service/* /usr/src/python-service/
+COPY --from=builder /usr/local/src/python-service/* /usr/local/src/python-service/
 COPY --from=virtualenv /opt/virtualenv /opt/virtualenv
 
 # The app listens on port 50051 by default using PORT environment variable.
 ENV PORT=50051
 EXPOSE 50051/udp
 
-CMD [ "python", "/usr/src/python-service/greeter_server.py" ]
+CMD [ "python", "/usr/local/src/python-service/greeter_server.py" ]


### PR DESCRIPTION
This commit moves the default source directory for both Python and
Golang code to /usr/loca/src, to respect the Linux File Hierarchy
Standards on where we should put our code.