### PR TITLE
NEW: Push Docker images to Docker Hub

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -17,9 +17,24 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Build Docker image for zeebo-go
-      working-directory: ${{ env.go-source-dir }}
-      run: docker image build . --file Dockerfile --tag zeebo-go:$(date +%Y%m%d-%H%M%S)
-    - name: Build Docker image for zeebo-python
-      working-directory: ${{ env.python-source-dir }}
-      run: docker image build . --file Dockerfile --tag python-go:$(date +%Y%m%d-%H%M%S)
+    - name: "Login to neverping's DockerHub private account"
+      uses: docker/login-action@v1 
+      with:
+        username: ${{ secrets.DOCKERHUB_LOGIN }}
+        password: ${{ secrets.DOCKERHUB_PASSWD }}
+    - name: Build and publish zeebo-python image into Docker Hub.
+      uses: docker/build-push-action@v2
+      with:
+        context: ${{ env.python-source-dir }}
+        file: "${{ env.python-source-dir }}/Dockerfile"
+        platforms: linux/amd64
+        push: true
+        tags: neverping/zeebo-python:latest
+    - name: Build and publish zeebo-go image into Docker Hub.
+      uses: docker/build-push-action@v2
+      with:
+        context: ${{ env.go-source-dir }}
+        file: "${{ env.go-source-dir }}/Dockerfile"
+        platforms: linux/amd64
+        push: true
+        tags: neverping/zeebo-go:latest


### PR DESCRIPTION
This commit will create and publish Docker container images to Docker
Hub once it finish building using Docker's official Github Actions.