### PR TITLE
NEW: Creating a Helm chart for Zeebo app

### DIFF
--- a/helm/charts/README.md
+++ b/helm/charts/README.md
@@ -1,0 +1,50 @@
+# zeebo
+
+Installs [zeebo](https://github.com/neverping/zeebo-app) using an Ingress controller and two services that uses [gCRP](https://grpc.io/) protocol.
+
+## TL;DR;
+
+```bash
+$ helm install zeebo
+```
+
+## Introduction
+
+This chart installs the [zeebo](https://github.com/neverping/zeebo-app) app which contains an Ingress controller on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager. It also creates an Golang app that receives the connection from the ingress controller and communicates with an internal app in Python.
+
+## Prerequisites
+  - Kubernetes 1.19.0 or above.
+  - An ingress controller installed. Any supported version by the Kubernetes cluster you are running.
+  - Helm 3.3.x or above.
+
+## Installing the Chart
+
+To install the chart with the release name called `my-release`:
+
+```bash
+$ helm install my-release --wait zeebo
+```
+
+Optionally you can select any values files from the `targets` directory. For example, for running on Minikube enviroment, you can run the command below:
+
+```bash
+$ helm install my-release --wait -f ../targets/minikube.yaml zeebo
+```
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` chart deployed in your cluster:
+
+```bash
+$ helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Minikube notes
+
+Please be aware to install the ingress plugin using this command below, otherwise the IP won't be exposed.
+
+```bash
+$ minikube addons enable ingress
+```

--- a/helm/charts/zeebo/Chart.yaml
+++ b/helm/charts/zeebo/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+appVersion: "1.0"
+description: Zeebo demo app
+name: zeebo
+version: 0.0.1
+keywords:
+  - zeebo
+  - devops
+home: "https://github.com/neverping/zeebo-app"
+sources:
+  - "https://github.com/neverping/zeebo-app"
+maintainers:
+  - name: "Willian Braga da Silva"
+    email: "neverping@gmail.com"
+    url: "https://github.com/neverping"
+icon: "https://avatars.githubusercontent.com/u/333393?s=60&v=4"
+deprecated: false

--- a/helm/charts/zeebo/templates/_helpers.tpl
+++ b/helm/charts/zeebo/templates/_helpers.tpl
@@ -1,0 +1,56 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{/*
+  Common annotations to be used in all resources
+*/}}
+{{- define "zeebo.annotations" -}}
+team: {{ .Values.team }}
+repository: {{ .Values.repository }}
+{{- end -}}
+
+{{/*
+  Common labels to be used in all resources
+  More info:
+  - https://helm.sh/docs/chart_best_practices/labels/
+  - https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/
+*/}}
+{{- define "zeebo.labelsCommon" -}}
+helm.sh/chart: {{ .Chart.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/part-of: {{ .Chart.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+  Selector labels Go
+*/}}
+{{- define "zeebo.selectorLabelsGo" -}}
+app.kubernetes.io/name: {{ .Values.apps.go.svc.name }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+  Selector labels Python
+*/}}
+{{- define "zeebo.selectorLabelsPython" -}}
+app.kubernetes.io/name: {{ .Values.apps.python.svc.name }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+  Common labels fo Go App
+*/}}
+{{- define "zeebo.labelsGo" -}}
+{{ include "zeebo.labelsCommon" . }}
+{{ include "zeebo.selectorLabelsGo" . }}
+{{- end -}}
+
+{{/*
+  Common labels fo Python App
+*/}}
+{{- define "zeebo.labelsPython" -}}
+{{ include "zeebo.labelsCommon" . }}
+{{ include "zeebo.selectorLabelsPython" . }}
+{{- end -}}

--- a/helm/charts/zeebo/templates/deployment-go.yaml
+++ b/helm/charts/zeebo/templates/deployment-go.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.apps.go.svc.name }}
+  annotations:
+    {{- include "zeebo.annotations" . | nindent 4 }}
+  labels:
+    {{- include "zeebo.labelsGo" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  strategy:
+    type: {{ .Values.upgrade.strategy }}
+    rollingUpdate:
+      maxSurge: {{ .Values.upgrade.maxSurge }}
+      maxUnavailable: {{ .Values.upgrade.maxUnavailable }}
+  selector:
+    matchLabels:
+      {{- include "zeebo.selectorLabelsGo" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "zeebo.selectorLabelsGo" . | nindent 8 }}
+    spec:
+      containers:
+      - name: {{ .Values.apps.go.svc.name }}
+        image: "{{ .Values.images.go.repository }}:latest"
+        imagePullPolicy: {{ .Values.images.pullPolicy }}
+        env:
+        - name: PORT
+          value: {{ .Values.apps.go.envs.port | quote }}
+        - name: SERVICE_ENDPOINT  
+          value: "{{ .Values.apps.python.svc.name }}:{{ .Values.apps.python.envs.port }}"
+        - name: REQUEST_TIMEOUT
+          value: {{ .Values.apps.go.envs.requestTimeout | quote }}
+        - name: IDLE_TIMEOUT
+          value: {{ .Values.apps.go.envs.idleTimeout | quote }}
+        ports:
+        - containerPort: {{ .Values.apps.go.envs.port }}
+          protocol: TCP
+{{ toYaml .Values.apps.go.probes | indent 8 }}
+        resources:
+{{ toYaml .Values.resources | indent 10 }}

--- a/helm/charts/zeebo/templates/deployment-python.yaml
+++ b/helm/charts/zeebo/templates/deployment-python.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.apps.python.svc.name }}
+  annotations:
+    {{- include "zeebo.annotations" . | nindent 4 }}
+  labels:
+    {{- include "zeebo.labelsPython" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  strategy:
+    type: {{ .Values.upgrade.strategy }}
+    rollingUpdate:
+      maxSurge: {{ .Values.upgrade.maxSurge }}
+      maxUnavailable: {{ .Values.upgrade.maxUnavailable }}
+  selector:
+    matchLabels:
+      {{- include "zeebo.selectorLabelsPython" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "zeebo.selectorLabelsPython" . | nindent 8 }}
+    spec:
+      containers:
+      - name: {{ .Values.apps.python.svc.name }}
+        image: "{{ .Values.images.python.repository }}:latest"
+        imagePullPolicy: {{ .Values.images.pullPolicy }}
+        env:
+        - name: PORT
+          value: {{ .Values.apps.python.envs.port | quote }}
+        ports:
+        - containerPort: {{ .Values.apps.python.envs.port }}
+          protocol: TCP
+{{ toYaml .Values.apps.python.probes | indent 8 }}
+        resources:
+{{ toYaml .Values.resources | indent 10 }}

--- a/helm/charts/zeebo/templates/ingress.yaml
+++ b/helm/charts/zeebo/templates/ingress.yaml
@@ -1,0 +1,33 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ .Values.apps.go.svc.name }}
+  labels:
+    {{- include "zeebo.labelsGo" . | nindent 4 }}
+  annotations:
+    nginx.ingress.kubernetes.io/default-backend: {{ .Values.apps.go.svc.name }}
+    nginx.ingress.kubernetes.io/custom-http-errors: "403,404,415"
+    {{- include "zeebo.annotations" . | nindent 4 }}
+    # This is need to proxy the callers hostname to the load balancer
+    use-proxy-protocol: "true"
+    kubernetes.io/ingress.class: "nginx"
+{{- with .Values.ingress.annotations }}
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+  defaultBackend:
+    service:
+      name: {{ .Values.apps.go.svc.name | quote }}
+      port:
+        number: {{ .Values.apps.go.envs.port }}
+  rules:
+    - host: {{ .Values.apps.go.svc.name }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ .Values.apps.go.svc.name }}
+                port:
+                  number: {{ .Values.apps.go.envs.port }}

--- a/helm/charts/zeebo/templates/pdb-go.yaml
+++ b/helm/charts/zeebo/templates/pdb-go.yaml
@@ -1,0 +1,13 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Values.apps.go.svc.name }}
+  annotations:
+    {{- include "zeebo.annotations" . | nindent 4 }}
+  labels:
+    {{- include "zeebo.labelsGo" . | nindent 4 }}
+spec:
+  maxUnavailable: 50%
+  selector:
+    matchLabels:
+      {{- include "zeebo.selectorLabelsGo" . | nindent 6 }}

--- a/helm/charts/zeebo/templates/pdb-python.yaml
+++ b/helm/charts/zeebo/templates/pdb-python.yaml
@@ -1,0 +1,13 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Values.apps.python.svc.name }}
+  annotations:
+    {{- include "zeebo.annotations" . | nindent 4 }}
+  labels:
+    {{- include "zeebo.labelsPython" . | nindent 4 }}
+spec:
+  maxUnavailable: 50%
+  selector:
+    matchLabels:
+      {{- include "zeebo.selectorLabelsPython" . | nindent 6 }}

--- a/helm/charts/zeebo/templates/service-go.yaml
+++ b/helm/charts/zeebo/templates/service-go.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.apps.go.svc.name }}
+  labels:
+    {{- include "zeebo.labelsGo" . | nindent 4 }}
+  annotations:
+    {{- include "zeebo.annotations" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.apps.go.envs.port }}
+      targetPort: {{ .Values.apps.go.envs.port }}
+      protocol: TCP
+      name: http
+  selector:
+  {{- include "zeebo.selectorLabelsGo" . | nindent 4 }}

--- a/helm/charts/zeebo/templates/service-python.yaml
+++ b/helm/charts/zeebo/templates/service-python.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.apps.python.svc.name }}
+  labels:
+    {{- include "zeebo.labelsPython" . | nindent 4 }}
+  annotations:
+    {{- include "zeebo.annotations" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.apps.python.envs.port }}
+      targetPort: {{ .Values.apps.python.envs.port }}
+      protocol: TCP
+      name: http
+  selector:
+  {{- include "zeebo.selectorLabelsPython" . | nindent 4 }}

--- a/helm/charts/zeebo/values.yaml
+++ b/helm/charts/zeebo/values.yaml
@@ -1,0 +1,100 @@
+ingress:
+  hostname: zeebo
+
+images:
+  python:
+    repository: neverping/zeebo-python
+  go:
+    repository: neverping/zeebo-go
+  pullPolicy: Always
+
+apps:
+  go:
+    svc:
+      name: "zeebo-go"
+    envs:
+      port: 4458
+      requestTimeout: 5
+      idleTimeout: 10
+    probes:
+      readinessProbe:
+        initialDelaySeconds: 5
+        tcpSocket:
+          port: 4458
+      livenessProbe:
+        initialDelaySeconds: 5
+        tcpSocket:
+          port: 4458
+  python:
+    svc:
+      name: "zeebo-python"
+    envs:
+      port: 50051
+    probes:
+      readinessProbe:
+        initialDelaySeconds: 5
+        tcpSocket:
+          port: 50051
+      livenessProbe:
+        initialDelaySeconds: 5
+        tcpSocket:
+          port: 50051
+
+# The team owning this chart
+team: "devops"
+repository: https://github.com/neverping/zeebo-app
+
+# Resource for the service
+# requests: When using the amount of memory the service is marked as a candidate for termination in case
+#           of out of memory on the node
+# limits: if the service reaches this amount it WILL be restarted
+resources:
+  limits:
+    cpu: 500m
+    memory: 512Mi
+  requests:
+    cpu: 500m
+    memory: 512Mi
+
+# number of instance to run
+replicaCount: 1
+
+# Upgrade strategy - RollingUpdate is currently the only one supported by TS at the moment
+upgrade:
+  strategy: RollingUpdate
+  maxSurge: 1
+  maxUnavailable: 1
+
+#
+#  Ingress for exposing the service inside the VPC
+#
+ingressinternal:
+  enabled: true
+  annotations:
+  # hosts will create a hostname accesible from inside the VPC
+  # in this case example.eu-west-1.test.ts.sv, some of the values comes from the site, environment, region above
+  tls:
+    enabled: false
+    client_certs_required: false
+
+#
+# Ingress for exposing the service on the internet
+#
+ingress:
+  enabled: true
+  annotations:
+    # Whitelist certain IP's to access this service
+    # nginx.ingress.kubernetes.io/whitelist-source-range: 192.30.252.0/22,185.199.108.0/22,5.56.144.196/32,5.56.144.198/32,142.254.28.146/32,178.49.148.100/32,87.243.3.34/32,109.166.189.50/32,78.40.84.83/32,4.53.137.82/32,173.247.199.142/32
+
+  # hosts will create a hostname accesible from the internet
+  # in this case example.eu-west-1.test.ts.sv, some of the values comes from the site, environment, region above
+  tls:
+    enabled: true
+    client_certs_required: false
+
+# Certificate for the service if TLS is enabled in the ingress section.
+# TODO: action required here!
+certs:
+  trusted_ca:
+  crt:
+  key:

--- a/helm/targets/minikube.yaml
+++ b/helm/targets/minikube.yaml
@@ -1,0 +1,1 @@
+### No new custom values as it for now.


### PR DESCRIPTION
This commit creates the Zeebo Helm chart which works on Minikube.

The chart exposes an Ingress controller to the Go App, which therefore
connects to the Python service exposed internally in the cluster using
the Services resource.