### PR TITLE
fix(images): use FQDN on images to satisfy Podman

### DIFF
--- a/services/go/Dockerfile
+++ b/services/go/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24-alpine AS builder
+FROM docker.io/library/golang:1.24-alpine AS builder
 
 RUN apk add --no-cache git
 

--- a/services/python/Dockerfile
+++ b/services/python/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-slim-trixie AS builder
+FROM docker.io/library/python:3.13-slim-trixie AS builder
 
 ENV LANG=C.UTF-8
 ENV PYTHONDONTWRITEBYTECODE=1
@@ -22,7 +22,7 @@ RUN python3 -m grpc_tools.protoc \
   --grpc_python_out=/usr/local/src/python-protobuf-generated \
   /usr/local/src/protobuf/helloworld.proto
 
-FROM python:3.13-slim-trixie AS app
+FROM docker.io/library/python:3.13-slim-trixie AS app
 LABEL maintainer="neverping@gmail.com"
 
 ENV VIRTUAL_ENV=/opt/virtualenv


### PR DESCRIPTION
Using the FQDN for images because Podman requests the user this long format.
