### PR TITLE
ci: use parallel build, upgrade actions, and apply zizmor

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -1,51 +1,55 @@
 name: Docker Image Build CI
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
 on:
   push:
     branches: [ main ]
-#  pull_request:
-#    branches: [ main ]
+  pull_request:
+    branches: [ main ]
 
 jobs:
-
   create-docker-images:
-    env:
-      go-source-dir: ./services/go
-      python-source-dir: ./services/python
-
-    # HINT: docker-slim has no Docker, it's required to build images.
+    name: Create Docker Images
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
-#TODO: Next steps for a parallel build and push.
-# https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners
-#    needs to inspect the "steps:" and also add these below
-#    strategy:
-#      matrix:
-#        platform: ["linux/amd64", "linux/arm64"]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - service: python
+            source-dir: ./services/python
+            dockerfile: Dockerfile
+            image-name: zeebo-python
+          - service: go
+            source-dir: ./services/go
+            dockerfile: Dockerfile
+            image-name: zeebo-go
 
     steps:
-    - uses: actions/checkout@v4
+    - name: Checkout code
+      uses: actions/checkout@v6 # zizmor: ignore[unpinned-uses] I trust in GitHub
+      with:
+        persist-credentials: false
     - name: Set up QEMU for multi-arch build
-      uses: docker/setup-qemu-action@v3
+      uses: docker/setup-qemu-action@v4 # zizmor: ignore[unpinned-uses] I trust in Docker
     - name: Set up Docker BuildX for multi-arch build
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4 # zizmor: ignore[unpinned-uses] I trust in Docker
     - name: "Login to neverping's DockerHub private account"
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4 # zizmor: ignore[unpinned-uses] I trust in Docker
       with:
         username: ${{ secrets.DOCKERHUB_LOGIN }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
-    - name: Build and publish zeebo-python image into Docker Hub.
-      uses: docker/build-push-action@v5
+    - name: Build and publish zeebo-${{ matrix.service }} image into Docker Hub.
+      uses: docker/build-push-action@v7 # zizmor: ignore[unpinned-uses] I trust in Docker
       with:
-        context: ${{ env.python-source-dir }}
-        file: "${{ env.python-source-dir }}/Dockerfile"
+        context: ${{ matrix.source-dir }}
+        file: "${{ matrix.source-dir }}/${{ matrix.dockerfile }}" # zizmor: ignore[template-injection] It's a fixed parameter, not user input.
         platforms: linux/amd64,linux/arm64
-        push: true
-        tags: neverping/zeebo-python:latest
-    - name: Build and publish zeebo-go image into Docker Hub.
-      uses: docker/build-push-action@v5
-      with:
-        context: ${{ env.go-source-dir }}
-        file: "${{ env.go-source-dir }}/Dockerfile"
-        platforms: linux/amd64,linux/arm64
-        push: true
-        tags: neverping/zeebo-go:latest
+        push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        tags: neverping/${{ matrix.image-name }}:latest


### PR DESCRIPTION
Finally I was able to build docker images in parallel, and only pushes them
when merged to master.

I also upgrade the actions to their latest release.

Finally, applied zizmor suggestions.
